### PR TITLE
[SPARK-53442]Make PrometheusServlet compatible with OpenMetrics

### DIFF
--- a/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
@@ -72,13 +72,13 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
   test("Counter should emit Prometheus counter") {
     val sink = createPrometheusServlet()
     val counter = new Counter
-    sink.registry.register("test.counter", counter)
+    sink.registry.register("counter1", counter)
     counter.inc(42)
 
     val snapshot = sink.getMetricsSnapshot()
 
-    assert(snapshot.contains("metrics_test_counter 42"))
-    assert(snapshot.contains("# TYPE metrics_test_counter counter"))
+    assert(snapshot.contains("metrics_counter1_total 42"))
+    assert(snapshot.contains("# TYPE metrics_counter1_total counter"))
   }
 
   test("Gauge should emit Prometheus gauge") {
@@ -86,11 +86,12 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val gauge = new Gauge[Double] {
       override def getValue: Double = 5.123
     }
-    sink.registry.register("test.gauge", gauge)
+    sink.registry.register("gauge1", gauge)
 
     val snapshot = sink.getMetricsSnapshot()
-    assert(snapshot.contains("metrics_test_gauge 5.123"))
-    assert(snapshot.contains("# TYPE metrics_test_gauge gauge"))
+    assert(snapshot.contains("metrics_gauge1 5.123"))
+    assert(snapshot.contains("# TYPE metrics_gauge1 gauge"))
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Timer should emit summary and rates") {
@@ -103,14 +104,16 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val snapshot = sink.getMetricsSnapshot()
 
     // Summary
-    assert(snapshot.contains("metrics_test_timer_count 2"))
-    assert(snapshot.contains("metrics_test_timer_sum"))
-    assert(snapshot.contains("""metrics_test_timer{quantile="0.5"}"""))
+    assert(snapshot.contains("metrics_test_timer_duration_seconds_count 2"))
+    assert(snapshot.contains("metrics_test_timer_duration_seconds_sum"))
+    assert(snapshot.contains("""metrics_test_timer_duration_seconds{quantile="0.5"}"""))
 
     // Rate
     assert(snapshot.contains("metrics_test_timer_m1_rate"))
     assert(snapshot.contains("metrics_test_timer_m5_rate"))
     assert(snapshot.contains("metrics_test_timer_m15_rate"))
+
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Histogram should emit summary") {
@@ -121,11 +124,12 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     histogram.update(75)
     histogram.update(150)
 
-    val output = sink.getMetricsSnapshot()
+    val snapshot = sink.getMetricsSnapshot()
 
-    assert(output.contains("metrics_test_hist_count 3"))
-    assert(output.contains("metrics_test_hist_sum"))
-    assert(output.contains("""metrics_test_hist{quantile="0.5"}"""))
+    assert(snapshot.contains("metrics_test_hist_count 3"))
+    assert(snapshot.contains("metrics_test_hist_sum"))
+    assert(snapshot.contains("""metrics_test_hist{quantile="0.5"}"""))
+    validateNumericLinesFormat(snapshot)
   }
 
   test("Meter should emit count and rates") {
@@ -133,14 +137,24 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     val meter = sink.registry.meter("test.meter")
     meter.mark(5)
 
-    val output = sink.getMetricsSnapshot()
+    val snapshot = sink.getMetricsSnapshot()
 
-    assert(output.contains("metrics_test_meter_count 5"))
-    assert(output.contains("metrics_test_meter_m1_rate"))
-    assert(output.contains("metrics_test_meter_m5_rate"))
-    assert(output.contains("metrics_test_meter_m15_rate"))
+    assert(snapshot.contains("metrics_test_meter_count_cumulative 5"))
+    assert(snapshot.contains("metrics_test_meter_m1_rate"))
+    assert(snapshot.contains("metrics_test_meter_m5_rate"))
+    assert(snapshot.contains("metrics_test_meter_m15_rate"))
+    validateNumericLinesFormat(snapshot)
   }
 
   private def createPrometheusServlet(): PrometheusServlet =
     new PrometheusServlet(new Properties, new MetricRegistry)
+
+  private def validateNumericLinesFormat(formattedOutput: String): Unit = {
+    val numericLinePattern = """^metrics_.*\s+([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)$""".r
+    val lines = formattedOutput.linesIterator.filterNot(_.startsWith("#")).toList
+    lines.foreach {
+      case numericLinePattern(_, _) => // valid
+      case badLine => fail(s"Invalid metric value format: $badLine")
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes PrometheusServlet publish snapshot that's compatible with OpenMetrics

### Why are the changes needed?

Adopting OpenMetrics ensures our metrics output is forward-compatible with common observability tools, not only Prometheus, but also OpenTelemetry, Datadog and others.

### Does this PR introduce _any_ user-facing change?

This shall still be compatible witrh Prometheus, while adding more compatibility. No direct user facing changes otherwise.

### How was this patch tested?

CIs with added unit test

### Was this patch authored or co-authored using generative AI tooling?

No

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
